### PR TITLE
Architecture Decision Record: Config As Code API

### DIFF
--- a/Decisions/20200707 - Config As Code API.md
+++ b/Decisions/20200707 - Config As Code API.md
@@ -1,0 +1,24 @@
+ - **Subject**: Public API Surface for Configuration As Code Feature
+ - **Decision date**: [when was the decision made]
+ - **Decision contributors**: Andrew Best, Paul Gradie, Adam McCoy, Matt Richardson, Andrew Moore, Rob Wagner
+ - **Decision maker**: TBA
+ - **Decision owner**: TBA
+
+Executive Summary: [Created once a decision is made]
+
+Options & Considerations: https://docs.google.com/document/d/1d9XBGd9akeHWn0B-sTPFV6KvfsR17abpBrHtoBRQadE
+
+Decisions: [what was the decision made]
+
+- Resource Identification:
+- Resource Location:
+- Resource Modification:
+- Retrieving VCS metadata:
+- Creating Releases:
+
+Revisions: 
+**[7/7/2020]**
+- Discussed the config-as-code spike carried out by Tribe Red with Matt Richardson and Andrew Moore. 
+- Arrived at the conclusion we want to discuss Resource Identification further
+- Agreed to an approach on Resource Location that would expose Hypermedia links off of the Branch resource
+- Confirmed approaches to modification, VCS metadata and Release creation implemented in the spike were appropriate (just needed productionising)

--- a/Decisions/20200707 - Config As Code API.md
+++ b/Decisions/20200707 - Config As Code API.md
@@ -1,8 +1,8 @@
- - **Subject**: Public API Surface for Configuration As Code Feature
- - **Decision date**: [when was the decision made]
- - **Decision contributors**: Andrew Best, Paul Gradie, Adam McCoy, Matt Richardson, Andrew Moore, Rob Wagner
- - **Decision maker**: TBA
- - **Decision owner**: TBA
+- **Subject**: Public API Surface for Configuration As Code Feature
+- **Decision date**: [when was the decision made]
+- **Decision contributors**: Andrew Best, Paul Gradie, Adam McCoy, Matt Richardson, Andrew Moore, Rob Wagner
+- **Decision maker**: TBA
+- **Decision owner**: School Of Architecture
 
 Executive Summary: [Created once a decision is made]
 
@@ -16,15 +16,9 @@ Decisions: [what was the decision made]
 - Retrieving VCS metadata:
 - Creating Releases:
 
-Revisions: 
-**[8/7/2020]**
-- Reviewed the proposed approaches with Rob Wagner
-- Confirmed the approach of exposing Hypermedia links for Project-related resources off of Branch resource
-- Agreed that default Hypermedia links for resources would still be retained on the Project resource. If a project was version-controlled, these links would point to resources on the default VCS branch for the project
-- Discussed the potential of version-controlled resources becoming the default and only way to store resources for projects in the future, and this necessitating the API design accommodate that possibility
+## Data Sources
 
-**[7/7/2020]**
-- Discussed the config-as-code spike carried out by Tribe Red with Matt Richardson and Andrew Moore. 
-- Arrived at the conclusion we want to discuss Resource Identification further
-- Agreed to an approach on Resource Location that would expose Hypermedia links off of the Branch resource
-- Confirmed approaches to modification, VCS metadata and Release creation implemented in the spike were appropriate (just needed productionising)
+Source listed below might provide additional context but keep in mind that they can disappear at any time.
+
+- [API Design Document](https://docs.google.com/document/d/1d9XBGd9akeHWn0B-sTPFV6KvfsR17abpBrHtoBRQadE)
+- [School Of Architecture Feedback](https://octopusdeploy.slack.com/archives/CTZT49JFJ/p1594593468361100)

--- a/Decisions/20200707 - Config As Code API.md
+++ b/Decisions/20200707 - Config As Code API.md
@@ -17,6 +17,12 @@ Decisions: [what was the decision made]
 - Creating Releases:
 
 Revisions: 
+**[8/7/2020]**
+- Reviewed the proposed approaches with Rob Wagner
+- Confirmed the approach of exposing Hypermedia links for Project-related resources off of Branch resource
+- Agreed that default Hypermedia links for resources would still be retained on the Project resource. If a project was version-controlled, these links would point to resources on the default VCS branch for the project
+- Discussed the potential of version-controlled resources becoming the default and only way to store resources for projects in the future, and this necessitating the API design accommodate that possibility
+
 **[7/7/2020]**
 - Discussed the config-as-code spike carried out by Tribe Red with Matt Richardson and Andrew Moore. 
 - Arrived at the conclusion we want to discuss Resource Identification further

--- a/Decisions/20200707 - Config As Code API.md
+++ b/Decisions/20200707 - Config As Code API.md
@@ -1,20 +1,43 @@
+# Overview
+
 - **Subject**: Public API Surface for Configuration As Code Feature
 - **Decision date**: [when was the decision made]
 - **Decision contributors**: Andrew Best, Paul Gradie, Adam McCoy, Matt Richardson, Andrew Moore, Rob Wagner
-- **Decision maker**: TBA
 - **Decision owner**: School Of Architecture
 
-Executive Summary: [Created once a decision is made]
+# Executive Summary
 
-Options & Considerations: https://docs.google.com/document/d/1d9XBGd9akeHWn0B-sTPFV6KvfsR17abpBrHtoBRQadE
+For the _Configuration As Code - Multi Branch Round Trip_ pitch, one of the key outcomes was an agreed approach for the API surface that would drive CaC functionality.
 
-Decisions: [what was the decision made]
+Problems and constraints were identified in the _Considerations_ document attached below, and potential solutions to the problems that satisfied the constraints developed and discussed with the School of Architecture.
+
+The final agreed decisions are documented below.
+
+# Detail
+
+## Considerations
+
+Captured in this document: https://docs.google.com/document/d/1d9XBGd9akeHWn0B-sTPFV6KvfsR17abpBrHtoBRQadE
+
+## Decisions
 
 - Resource Identification:
+
+VCS Resources will be identified by `{ProjectId}/{GitRef}` for resources that have a 1:1 relationship with a Project, and `{ProjectId}/{GitRef}/{ResourceSlug}` for resources that have a 1:\* relationship with Project.
+
 - Resource Location:
+
+VCS Resource location will be enabled by providing default links (links to the version of the resource on the default VCS branch) from the `Project` resource, and providing specific links to resources from other GitRef types from GitRef resources - for example, `VCSBranchResource` will have a `DeploymentProcess` Link that links to the DeploymentProcess for that branch.
+
 - Resource Modification:
+
+To modify a VCS-stored resource, commit details can optionally be supplied to the API.
+
+To model this, we will create `Envelope` resources that embed both the `Resource` being manipulated, along with the metadata required for the domain operation being executed - in this case, a `Commit` of a resource.
+
 - Retrieving VCS metadata:
-- Creating Releases:
+
+VCS branches, tags, and commits will be retrievable from hypermedia links exposed on the `Project` resource. This provides access to the _Resource Location_ capability described above.
 
 ## Data Sources
 

--- a/Decisions/20200707-ConfigAsCodeAPI.md
+++ b/Decisions/20200707-ConfigAsCodeAPI.md
@@ -1,9 +1,7 @@
 # Overview
 
 - **Subject**: Public API Surface for Configuration As Code Feature
-- **Decision date**: [when was the decision made]
-- **Decision contributors**: Andrew Best, Paul Gradie, Adam McCoy, Matt Richardson, Andrew Moore, Rob Wagner
-- **Decision owner**: School Of Architecture
+- **Decision date**: 07/07/2020
 
 # Executive Summary
 


### PR DESCRIPTION
### Overview
This PR introduces an Arhcitecture Decision Record for the Config As Code Public API.

### Contributing
Read through the ADR document and associated documents linked, and if you wish to contribute to the decision, comment on this PR or in #topic-architecture, referencing this PR and linking to your thread in a comment here.