### PR TITLE
Added examples

### DIFF
--- a/Decisions/20200716-ClientDesignPrinciples.md
+++ b/Decisions/20200716-ClientDesignPrinciples.md
@@ -49,9 +49,21 @@ Cons:
 
 
 
+## Examples
+
+[Runbook run command in Octopus CLI](https://github.com/OctopusDeploy/OctopusCLI/blob/28e6e2014c708593609979b4ad8e8f1e51c21c7b/source/Octopus.Cli/Commands/Runbooks/RunRunbookCommand.cs), [runbook run API in Octopus Client](https://github.com/OctopusDeploy/OctopusClients/blob/ba2cb799eaf3d8f993b01e3d6af965fb64c586be/source/Octopus.Client/Repositories/RunbookRepository.cs#L77-L86) and [runbook run endpoint in Octopus Server](https://github.com/OctopusDeploy/OctopusDeploy/blob/3de0f22fd5bcf6066a6396e1bfaa5de30960233f/source/Octopus.Server/Web/Api/Actions/RunbookRunForPublishedRunbookCreateAction.cs) are good examples of how this principle can be applied to implement an end to end scenario.   
+
+Both Octopus CLI and Octopus Client simply perform a few lookups and pass the data through to Octopus Server. If the runbook run endpoint allowed clients to refer to resources by either `Id` or `Name`  (as opposed to just by `Id`) then the lookups could be removed. `TODO`: Add link to ADR for `Resource References`.
+
+If an input parameter required by a server endpoint is difficult for the client to calculate and the server can't calculate it automatically then it might make sense to expose a template endpoint for that endpoint. Template endpoint is an ancillary endpoint that provides default values for the difficult to calculate parameters.
+
+[ReleaseTemplateAction](https://github.com/OctopusDeploy/OctopusDeploy/blob/c2ef1c646684e58e614922313e25434ca3022847/source/Octopus.Server/Web/Api/Actions/Releases/ReleaseTemplateAction.cs) endpoint is a template endpoint that can be used to retrieve some of the data required by [ReleaseCreateResponder](https://github.com/OctopusDeploy/OctopusDeploy/blob/2518dfd572f58209da1ec3fbaa4a3dfc85f4cbae/source/Octopus.Server/Web/Api/Actions/Releases/ReleaseCreateResponder.cs) endpoint. [NextVersionIncrement](https://github.com/OctopusDeploy/OctopusDeploy/blob/436c820fe691c3234f067672c4d7fc6184f7ca36/source/Octopus.Core/Resources/ReleaseTemplateResource.cs#L14) is a good example of an input parameter that might difficult to calculate on the client side.
+
+
+
 ## Data Sources
 
-Source listed below might provide additional context  but keep in mind that they can disappear at any time.
+Sources listed below might provide additional context  but keep in mind that they can disappear at any time.
 
 * [Should we keep Octopus Server clients simple?](https://octopusdeploy.slack.com/archives/C033W4273/p1594256099456300)
 * [Should we implement a new complex octo command in the client or in the server?](https://octopusdeploy.slack.com/archives/CTZT49JFJ/p1591323248186100)


### PR DESCRIPTION
The review of  `Design Principles For Octopus Server Clients`  ADR revealed that we need to provide examples to make it easier for engineers to apply this principle. This PR adds `Examples` section to the original ADR. 

`Examples` could be added to either the main ADR or they could form a separate ADR(s). I decided to add them to the main ADR because I think a self contained ADR is easier to understand than 2 separate ADRs or even more if the examples get updated.  I also propose that `Examples` section can be updated at any time as long as its content is still aligned with the main ADR.

I used existing code instead of pseudo code because I think a good example not only explains the concept but also provides a template for experiments.  This approach will not work well for ADRs that introduce new concepts. 