### PR TITLE
Added benefits for one controller per endpoint

### DIFF
--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -26,6 +26,14 @@ If an ASP.NET Controller endpoint exists for the HTTP Route + Verb pair coming i
 
 We have opted for a **One Controller Per Endpoint** structure, meaning for each HTTP Route + Verb, a Controller is created to serve that request.
 
+We have found many benefits of this approach (when compared to resource-centric controllers containing methods for many endpoints). Specifically:
+
+* Smaller code
+* Better dependency graph for endpoints, as 
+* Potentially testable endpoints (if we want them) thanks to fewer dependencies per-controller.
+
+Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each incliding some additional amount of code.
+
 There are only a couple of non-conforming controllers (See [SetTenantLogoController](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Server/Web/Controllers/Tenants/SetTenantLogoController.cs) for an example), in which `PUT` and `POST` implementations are identical, and so are served within the same Controller.
 
 Controllers are located under the `Octopus.Server.Web.Controllers.` namespace, collected in sub-directories based on the primary domain model they serve interactions for - for example, Tenant related Controllers are collected under `Octopus.Server.Web.Controllers.Tenants`.

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -24,7 +24,7 @@ If an ASP.NET Controller endpoint exists for the HTTP Route + Verb pair coming i
 
 ## Architecture
 
-We have opted for a **One Controller Per Endpoint** structure, meaning for each HTTP Route + Verb, a Controller is created to serve that request.
+We have opted for a **One Controller Per Endpoint** structure, meaning for each HTTP Route + Verb, a Controller is created to serve that request. The name of the controller should contain the name of the resource concerned, with a verb that explains what is being done to it (e.g. `Get`, `Create`, `Update`, `Delete`). The public action method on the controller should be named using this same verb.
 
 We have found many benefits of this approach (when compared to resource-centric controllers containing methods for many endpoints). Specifically:
 
@@ -33,6 +33,8 @@ We have found many benefits of this approach (when compared to resource-centric 
 * Potentially testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 
 Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each including some additional amount of code.
+
+Lastly, we feel that this approach aligns well with the **S** in **SOLID** - the Single Repsonsibility Principle - where each controller is responsible for a single thing: servicing a single endpoint.
 
 There are only a couple of non-conforming controllers (See [SetTenantLogoController](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Server/Web/Controllers/Tenants/SetTenantLogoController.cs) for an example), in which `PUT` and `POST` implementations are identical, and so are served within the same Controller.
 

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -29,7 +29,7 @@ We have opted for a **One Controller Per Endpoint** structure, meaning for each 
 We have found many benefits of this approach (when compared to resource-centric controllers containing methods for many endpoints). Specifically:
 
 * Controllers do only one thing each
-* Better dependency graph for endpoints, as there are fewer per controller
+* Controllers only take the dependencies required to do the one thing they need to do
 * Potentially unit testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 * We make a deliberate break away from controllers _having_ to be resource-aligned, giving more flexibility for controllers to exist that might model aggregate domain operations
 

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -28,7 +28,7 @@ We have opted for a **One Controller Per Endpoint** structure, meaning for each 
 
 We have found many benefits of this approach (when compared to resource-centric controllers containing methods for many endpoints). Specifically:
 
-* Smaller code
+* Controllers do only one thing each
 * Better dependency graph for endpoints, as there are fewer per controller
 * Potentially unit testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -29,7 +29,7 @@ We have opted for a **One Controller Per Endpoint** structure, meaning for each 
 We have found many benefits of this approach (when compared to resource-centric controllers containing methods for many endpoints). Specifically:
 
 * Smaller code
-* Better dependency graph for endpoints, as 
+* Better dependency graph for endpoints, as there are fewer per controller
 * Potentially testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 
 Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each incliding some additional amount of code.

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -31,6 +31,7 @@ We have found many benefits of this approach (when compared to resource-centric 
 * Controllers do only one thing each
 * Better dependency graph for endpoints, as there are fewer per controller
 * Potentially unit testable endpoints (if we want them) thanks to fewer dependencies per-controller.
+* We make a deliberate break away from controllers _having_ to be resource-aligned, giving more flexibility for controllers to exist that might model aggregate domain operations
 
 Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each including some additional amount of code.
 

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -30,7 +30,7 @@ We have found many benefits of this approach (when compared to resource-centric 
 
 * Smaller code
 * Better dependency graph for endpoints, as there are fewer per controller
-* Potentially testable endpoints (if we want them) thanks to fewer dependencies per-controller.
+* Potentially unit testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 
 Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each including some additional amount of code.
 

--- a/OctopusServer/Api/AspNet.md
+++ b/OctopusServer/Api/AspNet.md
@@ -32,7 +32,7 @@ We have found many benefits of this approach (when compared to resource-centric 
 * Better dependency graph for endpoints, as there are fewer per controller
 * Potentially testable endpoints (if we want them) thanks to fewer dependencies per-controller.
 
-Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each incliding some additional amount of code.
+Because we are making controllers more explicit and flattening that inheritance heirarchy, it allows them to contain more code without losing clarity. Things would get messy quickly if we had many endpoints per controller, each including some additional amount of code.
 
 There are only a couple of non-conforming controllers (See [SetTenantLogoController](https://github.com/OctopusDeploy/OctopusDeploy/blob/master/source/Octopus.Server/Web/Controllers/Tenants/SetTenantLogoController.cs) for an example), in which `PUT` and `POST` implementations are identical, and so are served within the same Controller.
 


### PR DESCRIPTION
The Single API Framework team have adopted a pattern of having one controller for each API endpoint. The PR aims to document the reasons and benefits behind this approach.